### PR TITLE
Add mailer host option to config.yml

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -64,6 +64,7 @@ doctrine:
 # Swiftmailer Configuration
 swiftmailer:
     transport: '%mailer_transport%'
+    host: '%mailer_host%'
     encryption: ssl
     username: '%mailer_user%'
     password: '%mailer_password%'


### PR DESCRIPTION
config.yml doesn't take into account the mailer host, which makes it impossible to send emails in a production environment, as SwiftMailer will then try to use localhost as the mailer host, which isn't always the case (external email providers, etc)